### PR TITLE
fix: #8 return empty list

### DIFF
--- a/celestia/node_api/blob.py
+++ b/celestia/node_api/blob.py
@@ -63,12 +63,14 @@ class BlobClient(Wrapper):
             deserializer (Callable | None): Custom deserializer. Defaults to None.
 
         Returns:
-            list[Blob] | None: The list, of blobs or None if not found.
+            list[Blob]: The list of blobs or [] if not found.
         """
 
-        def deserializer_(result):
+        def deserializer_(result) -> list['Blob']:
             if result is not None:
                 return [Blob(**kwargs) for kwargs in result]
+            else:
+                return []
 
         deserializer = deserializer if deserializer is not None else deserializer_
         namespaces = tuple(Namespace(namespace) for namespace in (namespace, *namespaces))
@@ -119,7 +121,6 @@ class BlobClient(Wrapper):
         return await self._rpc.call("blob.GetCommitmentProof", (height, Namespace(namespace), Commitment(commitment)),
                                     deserializer)
 
-    @handle_blob_error
     async def get_proof(self, height: int, namespace: Namespace, commitment: Commitment,
                         deserializer: Callable | None = None) -> list[Proof] | None:
         """ Retrieves proofs in the given namespaces at the given height by commitment.
@@ -128,16 +129,25 @@ class BlobClient(Wrapper):
             height (int): The block height.
             namespace (Namespace): The namespace of the proof.
             commitment (Commitment): The commitment to generate the proof for.
-            deserializer (Callable | None): Custom deserializer. Defaults to :meth:`~celestia.types.blob.Proof.deserializer`.
+            deserializer (Callable | None): Custom deserializer. Defaults to None.
 
         Returns:
-            list[Proof] | None: A list of proofs, or None if not found.
+            list[Proof]: A list of proofs or [] if not found.
         """
 
-        deserializer = deserializer if deserializer is not None else Proof.deserializer
+        def deserializer_(result) -> list['Proof']:
+            if result is not None:
+                return [Proof(**kwargs) for kwargs in result]
 
-        return await self._rpc.call("blob.GetProof", (height, Namespace(namespace), Commitment(commitment)),
-                                    deserializer)
+        deserializer = deserializer if deserializer is not None else deserializer_
+        try:
+            return await self._rpc.call("blob.GetProof", (height, Namespace(namespace), Commitment(commitment)),
+                                        deserializer)
+        except ConnectionError as e:
+            if 'blob: not found' in e.args[1].body['message'].lower():
+                return []
+            raise
+
 
     async def included(self, height: int, namespace: Namespace, proof: Proof, commitment: Commitment) -> bool:
         """ Checks whether a blob's given commitment(Merkle subtree root) is

--- a/celestia/node_api/blob.py
+++ b/celestia/node_api/blob.py
@@ -28,7 +28,7 @@ class BlobClient(Wrapper):
     """ Client for interacting with Celestia's Blob API."""
 
     @handle_blob_error
-    async def get(self, height: int, namespace: Namespace, commitment: Commitment,
+    async def get(self, height: int, namespace: Namespace, commitment: Commitment, *,
                   deserializer: Callable | None = None) -> Blob | None:
         """ Retrieves the blob by commitment under the given namespace and height.
 
@@ -102,7 +102,7 @@ class BlobClient(Wrapper):
         return await self._rpc.call("blob.Submit", (blobs, options), deserializer)
 
     @handle_blob_error
-    async def get_commitment_proof(self, height: int, namespace: Namespace, commitment: Commitment,
+    async def get_commitment_proof(self, height: int, namespace: Namespace, commitment: Commitment, *,
                                    deserializer: Callable | None = None) -> CommitmentProof | None:
         """ Generates a commitment proof for a share commitment.
 
@@ -121,7 +121,7 @@ class BlobClient(Wrapper):
         return await self._rpc.call("blob.GetCommitmentProof", (height, Namespace(namespace), Commitment(commitment)),
                                     deserializer)
 
-    async def get_proof(self, height: int, namespace: Namespace, commitment: Commitment,
+    async def get_proof(self, height: int, namespace: Namespace, commitment: Commitment, *,
                         deserializer: Callable | None = None) -> list[Proof] | None:
         """ Retrieves proofs in the given namespaces at the given height by commitment.
 
@@ -148,7 +148,6 @@ class BlobClient(Wrapper):
                 return []
             raise
 
-
     async def included(self, height: int, namespace: Namespace, proof: Proof, commitment: Commitment) -> bool:
         """ Checks whether a blob's given commitment(Merkle subtree root) is
         included at given height and under the namespace.
@@ -165,7 +164,7 @@ class BlobClient(Wrapper):
 
         return await self._rpc.call("blob.Included", (height, Namespace(namespace), proof, Commitment(commitment)))
 
-    async def subscribe(self, namespace: Namespace,
+    async def subscribe(self, namespace: Namespace, *,
                         deserializer: Callable | None = None) -> AsyncIterator[SubscriptionBlobResult | None]:
         """ Subscribe to published blobs from the given namespace as they are included.
 

--- a/celestia/node_api/das.py
+++ b/celestia/node_api/das.py
@@ -7,7 +7,7 @@ from ._RPC import Wrapper
 class DasClient(Wrapper):
     """ Client for interacting with Celestia's Das API."""
 
-    async def sampling_stats(self, deserializer: Callable | None = None) -> SamplingStats:
+    async def sampling_stats(self, *, deserializer: Callable | None = None) -> SamplingStats:
         """ Returns the current statistics over the DA sampling process.
 
         Args:

--- a/celestia/node_api/header.py
+++ b/celestia/node_api/header.py
@@ -25,7 +25,7 @@ class HeaderClient(Wrapper):
     """ Client for interacting with Celestia's Header API."""
 
     @handle_header_error
-    async def get_by_hash(self, header_hash: str, deserializer: Callable | None = None) -> ExtendedHeader | None:
+    async def get_by_hash(self, header_hash: str, *, deserializer: Callable | None = None) -> ExtendedHeader | None:
         """ Returns the header of the given hash from the node's header store.
 
         Args:
@@ -40,7 +40,7 @@ class HeaderClient(Wrapper):
 
         return await self._rpc.call("header.GetByHash", (header_hash,), deserializer)
 
-    async def get_by_height(self, height: int, deserializer: Callable | None = None) -> ExtendedHeader:
+    async def get_by_height(self, height: int, *, deserializer: Callable | None = None) -> ExtendedHeader:
         """ Returns the ExtendedHeader at the given height if it is currently available.
 
         Args:
@@ -55,7 +55,7 @@ class HeaderClient(Wrapper):
 
         return await self._rpc.call("header.GetByHeight", (int(height),), deserializer)
 
-    async def get_range_by_height(self, range_from: ExtendedHeader, range_to: int,
+    async def get_range_by_height(self, range_from: ExtendedHeader, range_to: int, *,
                                   deserializer: Callable | None = None) -> list[ExtendedHeader]:
         """ Returns the given range (from:to) of ExtendedHeaders from the node's header store
         and verifies that the returned headers are adjacent to each other.
@@ -77,7 +77,7 @@ class HeaderClient(Wrapper):
 
         return await self._rpc.call("header.GetRangeByHeight", (range_from, int(range_to)), deserializer)
 
-    async def local_head(self, deserializer: Callable | None = None) -> ExtendedHeader:
+    async def local_head(self, *, deserializer: Callable | None = None) -> ExtendedHeader:
         """ Returns the ExtendedHeader of the chain head.
 
         Args:
@@ -91,7 +91,7 @@ class HeaderClient(Wrapper):
 
         return await self._rpc.call("header.LocalHead", (), deserializer)
 
-    async def network_head(self, deserializer: Callable | None = None) -> ExtendedHeader:
+    async def network_head(self, *, deserializer: Callable | None = None) -> ExtendedHeader:
         """ Provides the Syncer's view of the current network head.
 
         Args:
@@ -105,7 +105,7 @@ class HeaderClient(Wrapper):
 
         return await self._rpc.call("header.NetworkHead", (), deserializer)
 
-    async def subscribe(self, deserializer: Callable | None = None) -> AsyncIterator[ExtendedHeader | None]:
+    async def subscribe(self, *, deserializer: Callable | None = None) -> AsyncIterator[ExtendedHeader | None]:
         """ Subscribes to recent ExtendedHeaders from the network.
 
         Args:
@@ -121,7 +121,7 @@ class HeaderClient(Wrapper):
             if subs_header_result is not None:
                 yield subs_header_result
 
-    async def sync_state(self, deserializer: Callable | None = None) -> State:
+    async def sync_state(self, *, deserializer: Callable | None = None) -> State:
         """ Returns the current state of the header Syncer.
 
         Args:
@@ -143,7 +143,7 @@ class HeaderClient(Wrapper):
         """
         return await self._rpc.call("header.SyncWait")
 
-    async def wait_for_height(self, height: int, deserializer: Callable | None = None) -> ExtendedHeader:
+    async def wait_for_height(self, height: int, *, deserializer: Callable | None = None) -> ExtendedHeader:
         """ Blocks until the header at the given height has been processed
         by the store or context deadline is exceeded.
 

--- a/celestia/node_api/p2p.py
+++ b/celestia/node_api/p2p.py
@@ -7,7 +7,7 @@ from ._RPC import Wrapper
 class P2PClient(Wrapper):
     """ Client for interacting with Celestia's P2P API."""
 
-    async def bandwidth_for_peer(self, peer_id: str, deserializer: Callable | None = None) -> BandwidthStats:
+    async def bandwidth_for_peer(self, peer_id: str, *, deserializer: Callable | None = None) -> BandwidthStats:
         """ Returns a Stats struct with bandwidth metrics associated with the given peer.ID.
         The metrics returned include all traffic sent / received for the peer, regardless of protocol.
 
@@ -23,7 +23,7 @@ class P2PClient(Wrapper):
 
         return await self._rpc.call("p2p.BandwidthForPeer", (peer_id,), deserializer)
 
-    async def bandwidth_for_protocol(self, protocol_id: str, deserializer: Callable | None = None) -> BandwidthStats:
+    async def bandwidth_for_protocol(self, protocol_id: str, *, deserializer: Callable | None = None) -> BandwidthStats:
         """ Returns a Stats struct with bandwidth metrics associated with the given protocol.ID.
 
         Args:
@@ -38,7 +38,7 @@ class P2PClient(Wrapper):
 
         return await self._rpc.call("p2p.BandwidthForProtocol", (protocol_id,), deserializer)
 
-    async def bandwidth_stats(self, deserializer: Callable | None = None) -> BandwidthStats:
+    async def bandwidth_stats(self, *, deserializer: Callable | None = None) -> BandwidthStats:
         """ Returns a Stats struct with bandwidth metrics for all data sent/received by the local peer,
         regardless of protocol or remote peer IDs.
 
@@ -88,7 +88,7 @@ class P2PClient(Wrapper):
         """
         return await self._rpc.call("p2p.Connectedness", (peer_id,))
 
-    async def info(self, deserializer: Callable | None = None) -> AddrInfo:
+    async def info(self, *, deserializer: Callable | None = None) -> AddrInfo:
         """ Returns address information about the host.
 
         Args:
@@ -130,7 +130,7 @@ class P2PClient(Wrapper):
         """
         return await self._rpc.call("p2p.NATStatus")
 
-    async def peer_info(self, peer_id: str, deserializer: Callable | None = None) -> AddrInfo:
+    async def peer_info(self, peer_id: str, *, deserializer: Callable | None = None) -> AddrInfo:
         """ Returns a small slice of information Peerstore has on the given peer.
 
         Args:
@@ -182,7 +182,7 @@ class P2PClient(Wrapper):
         """
         return await self._rpc.call("p2p.PubSubTopics")
 
-    async def resource_state(self, deserializer: Callable | None = None) -> ResourceManagerStat:
+    async def resource_state(self, *, deserializer: Callable | None = None) -> ResourceManagerStat:
         """ Returns the state of the resource manager.
 
         Args:

--- a/celestia/node_api/share.py
+++ b/celestia/node_api/share.py
@@ -1,6 +1,6 @@
 from typing import Callable
 
-from celestia.types import Namespace, Base64
+from celestia.types import Namespace
 from celestia.types.header import ExtendedHeader
 from celestia.types.share import ExtendedDataSquare, NamespaceData, SampleCoords, GetRangeResult
 from ._RPC import Wrapper
@@ -35,12 +35,14 @@ class ShareClient(Wrapper):
             deserializer (Callable | None): Custom deserializer. Defaults to None.
 
         Returns:
-            list[NamespaceData]: A list of NamespaceData objects.
+            list[NamespaceData]: A list of NamespaceData objects or [] if not found.
         """
 
         def deserializer_(result):
             if result is not None:
                 return [NamespaceData(**data) for data in result]
+            else:
+                return []
 
         deserializer = deserializer if deserializer is not None else deserializer_
 
@@ -64,7 +66,7 @@ class ShareClient(Wrapper):
 
         return await self._rpc.call("share.GetRange", (height, start, end), deserializer)
 
-    async def get_samples(self, header: ExtendedHeader, indices: list[SampleCoords]) -> list[Base64]:
+    async def get_samples(self, header: ExtendedHeader, indices: list[SampleCoords]) -> list[str]:
         """ Gets sample for given indices.
 
         Args:
@@ -72,11 +74,11 @@ class ShareClient(Wrapper):
             indices (list[SampleCoords]): A list of sample coordinates.
 
         Returns:
-            list[Base64]: A list of retrieved samples.
+            list[str]: A list of retrieved samples or [] if not found.
         """
-        return await self._rpc.call("share.GetSamples", (header, indices,))
+        return await self._rpc.call("share.GetSamples", (header, indices,), lambda result: result if result is not None else [])
 
-    async def get_share(self, height: int, row: int, col: int) -> Base64:
+    async def get_share(self, height: int, row: int, col: int) -> str:
         """ Gets a Share by coordinates in EDS.
 
         Args:
@@ -85,7 +87,7 @@ class ShareClient(Wrapper):
             col (int): The column index.
 
         Returns:
-            Base64: The retrieved share.
+            str: The retrieved share.
         """
         return await self._rpc.call("share.GetShare", (height, row, col,))
 

--- a/celestia/node_api/share.py
+++ b/celestia/node_api/share.py
@@ -9,7 +9,7 @@ from ._RPC import Wrapper
 class ShareClient(Wrapper):
     """ Client for interacting with Celestia's Share API."""
 
-    async def get_eds(self, height: int, deserializer: Callable | None = None) -> ExtendedDataSquare:
+    async def get_eds(self, height: int, *, deserializer: Callable | None = None) -> ExtendedDataSquare:
         """ Gets the full EDS identified by the given extended header.
 
         Args:
@@ -24,7 +24,7 @@ class ShareClient(Wrapper):
 
         return await self._rpc.call("share.GetEDS", (height,), deserializer)
 
-    async def get_namespace_data(self, height: int, namespace: Namespace,
+    async def get_namespace_data(self, height: int, namespace: Namespace, *,
                                  deserializer: Callable | None = None) -> list[NamespaceData]:
         """ Gets all shares from an EDS within the given namespace. Shares are returned
         in a row-by-row order if the namespace spans multiple rows.
@@ -48,7 +48,7 @@ class ShareClient(Wrapper):
 
         return await self._rpc.call("share.GetNamespaceData", (height, Namespace(namespace)), deserializer)
 
-    async def get_range(self, height: int, start: int, end: int,
+    async def get_range(self, height: int, start: int, end: int, *,
                         deserializer: Callable | None = None) -> GetRangeResult:
         """ Gets a list of shares and their corresponding proof.
 
@@ -76,7 +76,8 @@ class ShareClient(Wrapper):
         Returns:
             list[str]: A list of retrieved samples or [] if not found.
         """
-        return await self._rpc.call("share.GetSamples", (header, indices,), lambda result: result if result is not None else [])
+        return await self._rpc.call("share.GetSamples", (header, indices,),
+                                    lambda result: result if result is not None else [])
 
     async def get_share(self, height: int, row: int, col: int) -> str:
         """ Gets a Share by coordinates in EDS.

--- a/celestia/node_api/state.py
+++ b/celestia/node_api/state.py
@@ -19,7 +19,7 @@ class StateClient(Wrapper):
         """
         return await self._rpc.call("state.AccountAddress")
 
-    async def balance(self, deserializer: Callable | None = None) -> Balance:
+    async def balance(self, *, deserializer: Callable | None = None) -> Balance:
         """ Retrieves the Celestia coin balance for the node's account/signer
         and verifies it against the corresponding block's AppHash.
 
@@ -34,7 +34,7 @@ class StateClient(Wrapper):
 
         return await self._rpc.call("state.Balance", (), deserializer)
 
-    async def balance_for_address(self, address: str, deserializer: Callable | None = None) -> Balance:
+    async def balance_for_address(self, address: str, *, deserializer: Callable | None = None) -> Balance:
         """ Retrieves the Celestia coin balance for the given address and verifies the returned balance
         against the corresponding block's AppHash. NOTE: the balance returned is the balance reported
         by the block right before the node's current head (head-1). This is due to the fact that for
@@ -52,7 +52,7 @@ class StateClient(Wrapper):
 
         return await self._rpc.call("state.BalanceForAddress", (address,), deserializer)
 
-    async def begin_redelegate(self, src_val_addr: str, dst_val_addr: str, amount: int,
+    async def begin_redelegate(self, src_val_addr: str, dst_val_addr: str, amount: int, *,
                                deserializer: Callable | None = None, **config: Unpack[TxConfig]) -> TXResponse:
         """ Sends a user's delegated tokens to a new validator for redelegation.
 
@@ -72,7 +72,7 @@ class StateClient(Wrapper):
         return await self._rpc.call("state.BeginRedelegate", (src_val_addr, dst_val_addr, str(amount), config),
                                     deserializer)
 
-    async def cancel_unbonding_delegation(self, val_addr: str, amount: int, height: int,
+    async def cancel_unbonding_delegation(self, val_addr: str, amount: int, height: int, *,
                                           deserializer: Callable | None = None,
                                           **config: Unpack[TxConfig]) -> TXResponse:
         """ Cancels a user's pending undelegation from a validator.
@@ -93,7 +93,7 @@ class StateClient(Wrapper):
         return await self._rpc.call("state.CancelUnbondingDelegation", (val_addr, str(amount), str(height), config),
                                     deserializer)
 
-    async def delegate(self, del_addr: str, amount: int, deserializer: Callable | None = None,
+    async def delegate(self, del_addr: str, amount: int, *, deserializer: Callable | None = None,
                        **config: Unpack[TxConfig]) -> TXResponse:
         """ Sends a user's liquid tokens to a validator for delegation.
 
@@ -111,7 +111,7 @@ class StateClient(Wrapper):
 
         return await self._rpc.call("state.Delegate", (del_addr, str(amount), config), deserializer)
 
-    async def grant_fee(self, grantee: str, amount: int, deserializer: Callable | None = None,
+    async def grant_fee(self, grantee: str, amount: int, *, deserializer: Callable | None = None,
                         **config: Unpack[TxConfig]) -> TXResponse:
         """ Grants a fee allowance to the specified grantee.
 
@@ -129,7 +129,7 @@ class StateClient(Wrapper):
 
         return await self._rpc.call("state.GrantFee", (grantee, str(amount), config), deserializer)
 
-    async def query_delegation(self, val_addr: str, deserializer: Callable | None = None) -> QueryDelegationResponse:
+    async def query_delegation(self, val_addr: str, *, deserializer: Callable | None = None) -> QueryDelegationResponse:
         """ Retrieves the delegation information between a delegator and a validator.
 
         Args:
@@ -144,7 +144,7 @@ class StateClient(Wrapper):
 
         return await self._rpc.call("state.QueryDelegation", (val_addr,), deserializer)
 
-    async def query_redelegations(self, src_val_addr: str, dst_val_addr: str,
+    async def query_redelegations(self, src_val_addr: str, dst_val_addr: str, *,
                                   deserializer: Callable | None = None) -> QueryRedelegationResponse:
         """ Retrieves the status of the redelegations between a delegator and a validator.
 
@@ -161,7 +161,7 @@ class StateClient(Wrapper):
 
         return await self._rpc.call("state.QueryRedelegations", (src_val_addr, dst_val_addr), deserializer)
 
-    async def query_unbonding(self, val_addr: str,
+    async def query_unbonding(self, val_addr: str, *,
                               deserializer: Callable | None = None) -> QueryUnbondingDelegationResponse:
         """ Retrieves the unbonding status between a delegator and a validator.
 
@@ -177,7 +177,7 @@ class StateClient(Wrapper):
 
         return await self._rpc.call("state.QueryUnbonding", (val_addr,), deserializer)
 
-    async def revoke_grant_fee(self, grantee: str, deserializer: Callable | None = None,
+    async def revoke_grant_fee(self, grantee: str, *, deserializer: Callable | None = None,
                                **config: Unpack[TxConfig]) -> TXResponse:
         """ Revokes a previously granted fee allowance.
 
@@ -208,7 +208,7 @@ class StateClient(Wrapper):
         blobs = tuple(types.normalize_blob(blob) if blob.commitment is None else blob for blob in (blob, *blobs))
         return await self._rpc.call("state.SubmitPayForBlob", (blobs, config))
 
-    async def transfer(self, to: str, amount: int, deserializer: Callable | None = None,
+    async def transfer(self, to: str, amount: int, *, deserializer: Callable | None = None,
                        **config: Unpack[TxConfig]) -> TXResponse:
         """ Sends the given amount of coins from default wallet of the node to the given account address.
 
@@ -226,7 +226,7 @@ class StateClient(Wrapper):
 
         return await self._rpc.call("state.Transfer", (to, str(amount), config), deserializer)
 
-    async def undelegate(self, del_addr: str, amount: int, deserializer: Callable | None = None,
+    async def undelegate(self, del_addr: str, amount: int, *, deserializer: Callable | None = None,
                          **config: Unpack[TxConfig]) -> TXResponse:
         """ Undelegates a user's delegated tokens, unbonding them from the current validator.
 

--- a/celestia/types/blob.py
+++ b/celestia/types/blob.py
@@ -50,19 +50,6 @@ class Proof:
         self.end = end
         self.is_max_namespace_ignored = is_max_namespace_ignored
 
-    @staticmethod
-    def deserializer(result) -> list['Proof']:
-        """ Deserializes a list of proof entries from a given result.
-
-        Args:
-            result (list[dict]): The serialized response data.
-
-        Returns:
-            list[Proof]: A list of deserialized Proof objects.
-        """
-        if result is not None:
-            return [Proof(**kwargs) for kwargs in result]
-
 
 @dataclass
 class RowProofEntry:

--- a/celestia/types/state.py
+++ b/celestia/types/state.py
@@ -170,7 +170,7 @@ class Redelegation:
         self.delegator_address = delegator_address
         self.validator_src_address = validator_src_address
         self.validator_dst_address = validator_dst_address
-        self.entries = tuple(RedelegationEntry(**entry) for entry in entries)
+        self.entries = tuple(RedelegationEntry(**entry) for entry in entries) if entries is not None else []
 
 
 @dataclass

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-asyncio
+pydantic

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -12,7 +12,7 @@ async def test_send_blobs(node_provider):
     client = Client(port=bridge.port['26658/tcp'])
     async with client.connect(auth_token) as api:
         blobs = await api.blob.get_all(1, b'abc')
-        assert blobs is None
+        assert blobs == []
 
         result = await api.blob.submit(
             Blob(b'abc', b'0123456789'),
@@ -43,10 +43,10 @@ async def test_send_blobs(node_provider):
         assert blob.data == b'QWERTYUIOP'
 
         proof = await api.blob.get_proof(1, b'abc', b'ASDFGHJKL')
-        assert proof is None
+        assert proof == []
 
         proof = await api.blob.get_proof(result.height, b'abc', result.commitments[1])
-        assert proof is not None
+        assert proof
 
         included = await api.blob.included(result.height, b'xyz', proof, result.commitments[1])
         assert not included

--- a/tests/test_deserializers.py
+++ b/tests/test_deserializers.py
@@ -1,0 +1,25 @@
+import pytest
+from pydantic import BaseModel
+
+from celestia.node_api import Client
+
+
+@pytest.mark.asyncio
+async def test_deserializers(node_provider):
+    bridge, auth_token = await node_provider('bridge-0')
+    client = Client(port=bridge.port['26658/tcp'])
+
+    class CustomBalanceModel(BaseModel):
+        amount: int
+        denom: str
+
+    async with client.connect(auth_token) as api:
+        last_height = await api.header.local_head(deserializer=lambda data: int(data['header']['height']))
+        assert isinstance(last_height, int)
+
+        balance = await api.state.balance(deserializer=CustomBalanceModel.model_validate)
+        assert isinstance(balance.amount, int)
+        assert balance.amount
+
+        with pytest.raises(TypeError):
+            await api.state.balance(CustomBalanceModel.model_validate)

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -17,6 +17,8 @@ async def test_share(node_provider):
         )
 
         eds = await api.share.get_eds(result.height)
+        empty_gnd = await api.share.get_namespace_data(result.height, b'abcd')
+        assert empty_gnd == []
         gnd = await api.share.get_namespace_data(result.height, b'abc')
         range_data = await api.share.get_range(result.height, 1, 2)
         samples = await api.share.get_samples((await api.header.get_by_height(result.height)),

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -109,8 +109,9 @@ async def test_undelegate(node_provider, validator_addresses):
         if 'too many unbonding delegation entries for' in e.args[0]:
             print(""" The unbound pool is full. To test the functions undelegate, query_unbonding,
                   cancel_unbonding_delegation the network needs to be recreated
-                  """
-                  )
+                  """)
+        else:
+            raise e
 
 
 @pytest.mark.asyncio
@@ -137,14 +138,14 @@ async def test_delegating(node_provider, validator_addresses):
             assert (await api.state.query_delegation(
                 validator1)).delegation_response.balance.amount == amount_validator1_before_delegation + 10000
 
-            await api.state.begin_redelegate(validator1, validator2, 10000)
+            await api.state.begin_redelegate(validator1, validator2, 9999)
+            await asyncio.sleep(5)
             assert (await api.state.query_delegation(
-                validator1)).delegation_response.balance.amount == amount_validator1_before_delegation
+                validator1)).delegation_response.balance.amount == amount_validator1_before_delegation + 1
             assert (await api.state.query_delegation(
-                validator2)).delegation_response.balance.amount == amount_validator2_before_delegation + 10000
-
+                validator2)).delegation_response.balance.amount == amount_validator2_before_delegation + 9999
             querry = await api.state.query_redelegations(validator1, validator2)
-            assert querry.redelegation_responses[0].entries[-1].balance == 10000
+            assert querry.redelegation_responses[0].entries[-1].balance == 9999
 
             with pytest.raises(ValueError):
                 await api.state.begin_redelegate(validator1, validator1, 3000)
@@ -152,10 +153,10 @@ async def test_delegating(node_provider, validator_addresses):
                 await api.state.query_redelegations(validator1, validator1)
             with pytest.raises(ValueError):
                 await api.state.query_redelegations(validator2, validator1)
-
     except ValueError as e:
         if 'too many redelegation entries for (delegator, src-validator, dst-validator)' in e.args[0]:
             print(""" The redelegation entries is full. To test the functions query_delegation, delegate,
                   begin_redelegate the network needs to be recreated
-                  """
-                  )
+                  """)
+        else:
+            raise e


### PR DESCRIPTION
This PR fixes an issue where list-returning methods didn't return empty lists when no data was found.

Closes #8